### PR TITLE
Update cumtraps to cumulative_trapezoid

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -61,7 +61,7 @@ pytest==6.2.4
 python-dateutil==2.8.1
 pyzmq==22.1.0
 qdldl==0.1.5.post0
-scipy==1.7.0
+scipy==1.15.0
 scs==2.1.4
 Send2Trash==1.7.1
 six==1.16.0

--- a/pynumdiff/linear_model/_linear_model.py
+++ b/pynumdiff/linear_model/_linear_model.py
@@ -414,7 +414,7 @@ def __integrate_dxdt_hat_matrix__(dxdt_hat, dt):
     #assert isinstance(dxdt_hat, np.matrix)
     if len(dxdt_hat.shape) == 1:
         dxdt_hat = np.reshape(dxdt_hat, [1, len(dxdt_hat)])
-    x = np.array(scipy.integrate.cumtrapz(dxdt_hat, axis=1))
+    x = np.array(scipy.integrate.cumulative_trapezoid(dxdt_hat, axis=1))
     first_value = x[:, 0:1] - np.mean(dxdt_hat[:, 0:1], axis=1).reshape(dxdt_hat.shape[0], 1)
     x = np.hstack((first_value, x))*dt
     return x

--- a/pynumdiff/utils/utility.py
+++ b/pynumdiff/utils/utility.py
@@ -213,7 +213,7 @@ def finite_difference(x, dt):
 # Trapazoidal integration, with interpolated final point so that the lengths match.
 def integrate_dxdt_hat(dxdt_hat, dt):
     """
-    Wrapper for scipy.integrate.cumtrapz to integrate dxdt_hat that ensures the integral has the same length
+    Wrapper for scipy.integrate.cumulative_trapezoid to integrate dxdt_hat that ensures the integral has the same length
 
     :param dxdt_hat: estimate derivative of timeseries
     :type dxdt_hat: np.array
@@ -224,7 +224,7 @@ def integrate_dxdt_hat(dxdt_hat, dt):
     :return: integral of dxdt_hat
     :rtype: np.array
     """
-    x = scipy.integrate.cumtrapz(dxdt_hat)
+    x = scipy.integrate.cumulative_trapezoid(dxdt_hat)
     first_value = x[0] - np.mean(dxdt_hat[0:1])
     x = np.hstack((first_value, x))*dt
     return x


### PR DESCRIPTION
As of scipy version 1.14.0, `cumtrapz` [has been deprecated in favor of `cumulative_trapezoid`](https://docs.scipy.org/doc/scipy-1.15.0/release/1.14.0-notes.html#expired-deprecations). This is raising errors in the trapezoidal integration function, so the name should be modified to the new function.