### PR TITLE
made first order actually first order and added fourth order

### DIFF
--- a/pynumdiff/finite_difference/__init__.py
+++ b/pynumdiff/finite_difference/__init__.py
@@ -1,5 +1,5 @@
 """This module implements some common finite difference schemes
 """
-from ._finite_difference import first_order, second_order
+from ._finite_difference import first_order, second_order, fourth_order
 
-__all__ = ['first_order', 'second_order'] # So these get treated as direct members of the module by sphinx
+__all__ = ['first_order', 'second_order', 'fourth_order'] # So these get treated as direct members of the module by sphinx

--- a/pynumdiff/tests/test_diff_methods.py
+++ b/pynumdiff/tests/test_diff_methods.py
@@ -3,12 +3,12 @@ from matplotlib import pyplot
 from pytest import mark
 from warnings import warn
 
+from ..finite_difference import first_order, second_order, fourth_order
 from ..linear_model import lineardiff, polydiff, savgoldiff, spectraldiff
 from ..total_variation_regularization import velocity, acceleration, jerk, iterative_velocity, smooth_acceleration, jerk_sliding
 from ..kalman_smooth import constant_velocity, constant_acceleration, constant_jerk
 from ..smooth_finite_difference import mediandiff, meandiff, gaussiandiff, friedrichsdiff, butterdiff, splinediff
-from ..finite_difference import first_order, second_order
-# Function aliases for testing cases where parameters change the behavior in a big way
+# Function alias for testing a case where parameters change the behavior in a big way
 def iterated_first_order(*args, **kwargs): return first_order(*args, **kwargs)
 
 dt = 0.1
@@ -33,6 +33,7 @@ diff_methods_and_params = [
     (first_order, {}), # empty dictionary for the case of no parameters. no params -> no diff in new vs old
     (iterated_first_order, {'num_iterations':5}), (iterated_first_order, [5], {'iterate':True}),
     (second_order, {}),
+    (fourth_order, {}),
     (lineardiff, {'order':3, 'gamma':5, 'window_size':11, 'solver':'CLARABEL'}), (lineardiff, [3, 5, 11], {'solver':'CLARABEL'}),
     (polydiff, {'polynomial_order':2, 'window_size':3}), (polydiff, [2, 3]),
     (savgoldiff, {'polynomial_order':2, 'window_size':4, 'smoothing_win':4}), (savgoldiff, [2, 4, 4]),
@@ -60,23 +61,29 @@ diff_methods_and_params = [
 # big ol' table by the method, then the test function, then the pair of quantities we're comparing.
 error_bounds = {
     first_order: [[(-25, -25), (-25, -25), (0, 0), (1, 1)],
-                  [(-25, -25), (-13, -14), (0, 0), (1, 1)],
-                  [(-25, -25), (0, 0), (0, 0), (1, 0)],
+                  [(-25, -25), (-13, -13), (0, 0), (1, 1)],
                   [(-25, -25), (0, 0), (0, 0), (1, 1)],
+                  [(-25, -25), (1, 0), (0, 0), (1, 1)],
                   [(-25, -25), (2, 2), (0, 0), (2, 2)],
                   [(-25, -25), (3, 3), (0, 0), (3, 3)]],
-    iterated_first_order: [[(-8, -9), (-11, -11), (0, -1), (0, 0)],
-                           [(-6, -6), (-6, -7), (0, -1), (0, 0)],
-                           [(-1, -1), (0, 0), (0, -1), (0, 0)],
-                           [(0, 0), (1, 0), (0, 0), (1, 0)],
-                           [(1, 1), (2, 2), (1, 1), (2, 2)],
-                           [(1, 1), (3, 3), (1, 1), (3, 3)]],
+    iterated_first_order: [[(-8, -9), (-25, -25), (0, 0), (1, 1)],
+                           [(-6, -6), (-6, -7), (0, 0), (1, 1)],
+                           [(1, 0), (1, 0), (1, 1), (1, 1)],
+                           [(1, 0), (1, 1), (1, 0), (1, 1)],
+                           [(2, 2), (3, 2), (2, 2), (3, 2)],
+                           [(2, 2), (3, 3), (2, 2), (3, 3)]],
     second_order: [[(-25, -25), (-25, -25), (0, 0), (1, 1)],
                    [(-25, -25), (-13, -13), (0, 0), (1, 1)],
                    [(-25, -25), (-13, -13), (0, 0), (1, 1)],
                    [(-25, -25), (0, -1), (0, 0), (1, 1)],
                    [(-25, -25), (1, 1), (0, 0), (1, 1)],
                    [(-25, -25), (3, 3), (0, 0), (3, 3)]],
+    fourth_order: [[(-25, -25), (-25, -25), (0, 0), (1, 1)],
+                   [(-25, -25), (-13, -13), (0, 0), (1, 1)],
+                   [(-25, -25), (-13, -13), (0, 0), (1, 1)],
+                   [(-25, -25), (-2, -2), (0, 0), (1, 1)],
+                   [(-25, -25), (1, 0), (0, 0), (1, 1)],
+                   [(-25, -25), (2, 2), (0, 0), (2, 2)]],
     lineardiff: [[(-6, -6), (-5, -6), (0, -1), (0, 0)],
                  [(0, 0), (1, 1), (0, 0), (1, 1)],
                  [(1, 0), (2, 2), (1, 0), (2, 2)],


### PR DESCRIPTION
Addressing #104. The resulting `first_order` is biased to one side, resulting in drift when it's iterated:

<img width="1181" alt="Screenshot 2025-07-01 at 10 23 17" src="https://github.com/user-attachments/assets/7e88ebc1-8377-4d02-97bf-a69e8c206498" />

This is likely why you attempted some forward-backward averaging, @florisvb.

Honestly, is it worth keeping around `first_order`? My guess is it's not in wide usage, because the higher order methods are equally usable and right there for the taking. Iterating `first_order` might be a thing people do, but in that case they're actually iterating `second_order`, so we should update the code to reflect that and feed them a warning if they try to call `first_order`.