### PR TITLE
Make backers public

### DIFF
--- a/pynumdiff/finite_difference/__init__.py
+++ b/pynumdiff/finite_difference/__init__.py
@@ -1,5 +1,5 @@
 """This module implements some common finite difference schemes
 """
-from ._finite_difference import first_order, second_order, fourth_order
+from ._finite_difference import finite_difference, first_order, second_order, fourth_order
 
-__all__ = ['first_order', 'second_order', 'fourth_order'] # So these get treated as direct members of the module by sphinx
+__all__ = ['finite_difference', 'first_order', 'second_order', 'fourth_order'] # So these get treated as direct members of the module by sphinx

--- a/pynumdiff/finite_difference/_finite_difference.py
+++ b/pynumdiff/finite_difference/_finite_difference.py
@@ -4,11 +4,15 @@ from pynumdiff.utils import utility
 from warnings import warn
 
 
-def _finite_difference(x, dt, num_iterations, order):
-    """Helper for all finite difference methods, since their iteration structure is all the same.
+def finite_difference(x, dt, num_iterations, order):
+    """Perform iterated finite difference of a given order. This serves as the common backing function for
+    all other methods in this module, since their iteration structure is all the same.
     
+    :param np.array[float] x: data to differentiate
+    :param float dt: step size
+    :param int num_iterations: number of iterations. If >1, the derivative is integrated with trapezoidal
+            rule, that result is finite-differenced again, and the cycle is repeated num_iterations-1 times
     :param int order: 1, 2, or 4, controls which finite differencing scheme to employ
-    For other parameters and return values, see public function docstrings
     """
     if num_iterations < 1: raise ValueError("num_iterations must be >0")
     if order not in [1, 2, 4]: raise ValueError("order must be 1, 2, or 4")
@@ -61,7 +65,7 @@ def _finite_difference(x, dt, num_iterations, order):
 
 
 def first_order(x, dt, params=None, options={}, num_iterations=1):
-    """First-order centered difference method
+    """First-order difference method
 
     :param np.array[float] x: data to differentiate
     :param float dt: step size

--- a/pynumdiff/finite_difference/_finite_difference.py
+++ b/pynumdiff/finite_difference/_finite_difference.py
@@ -27,8 +27,8 @@ def finite_difference(x, dt, num_iterations, order):
             dxdt_hat[-1] = dxdt_hat[-2] # using stencil -1,0 vs stencil 0,1 you get an expression for the same value
         elif order == 2:
             dxdt_hat[1:-1] = (x_hat[2:] - x_hat[:-2])/2 # second-order center-difference formula
-            dxdt_hat[0] = x_hat[1] - x_hat[0]
-            dxdt_hat[-1] = x_hat[-1] - x_hat[-2] # use first-order endpoint formulas so as not to amplify noise. See #104
+            dxdt_hat[0] = (-3 * x_hat[0] + 4 * x_hat[2] - x_hat[4])/4
+            dxdt_hat[-1] = (3 * x_hat[-1] - 4 * x_hat[-3] + x_hat[-5])/4 # use spaced out stencil to get endpoint formulas that does not amplify noise. See #104
         elif order == 4:
             dxdt_hat[2:-2] = (8*(x_hat[3:-1] - x_hat[1:-3]) - x_hat[4:] + x_hat[:-4])/12 # fourth-order center-difference
             dxdt_hat[1] = (x_hat[2] - x_hat[0])/2
@@ -85,7 +85,7 @@ def first_order(x, dt, params=None, options={}, num_iterations=1):
         warn("`params` and `options` parameters will be removed in a future version. Use `num_iterations` instead.", DeprecationWarning)
         num_iterations = params[0] if isinstance(params, list) else params
 
-    return _finite_difference(x, dt, num_iterations, 1)
+    return finite_difference(x, dt, num_iterations, 1)
 
 
 def second_order(x, dt, num_iterations=1):
@@ -100,7 +100,7 @@ def second_order(x, dt, num_iterations=1):
              - **x_hat** -- original x if :code:`num_iterations=1`, else smoothed x that yielded dxdt_hat
              - **dxdt_hat** -- estimated derivative of x
     """
-    return _finite_difference(x, dt, num_iterations, 2)
+    return finite_difference(x, dt, num_iterations, 2)
 
 
 def fourth_order(x, dt, num_iterations=1):
@@ -115,4 +115,4 @@ def fourth_order(x, dt, num_iterations=1):
              - **x_hat** -- original x if :code:`num_iterations=1`, else smoothed x that yielded dxdt_hat
              - **dxdt_hat** -- estimated derivative of x
     """
-    return _finite_difference(x, dt, num_iterations, 4)
+    return finite_difference(x, dt, num_iterations, 4)

--- a/pynumdiff/finite_difference/_finite_difference.py
+++ b/pynumdiff/finite_difference/_finite_difference.py
@@ -6,7 +6,7 @@ from warnings import warn
 
 def finite_difference(x, dt, num_iterations, order):
     """Perform iterated finite difference of a given order. This serves as the common backing function for
-    all other methods in this module, since their iteration structure is all the same.
+    all other methods in this module.
     
     :param np.array[float] x: data to differentiate
     :param float dt: step size
@@ -27,8 +27,8 @@ def finite_difference(x, dt, num_iterations, order):
             dxdt_hat[-1] = dxdt_hat[-2] # using stencil -1,0 vs stencil 0,1 you get an expression for the same value
         elif order == 2:
             dxdt_hat[1:-1] = (x_hat[2:] - x_hat[:-2])/2 # second-order center-difference formula
-            dxdt_hat[0] = (-3 * x_hat[0] + 4 * x_hat[2] - x_hat[4])/4
-            dxdt_hat[-1] = (3 * x_hat[-1] - 4 * x_hat[-3] + x_hat[-5])/4 # use spaced out stencil to get endpoint formulas that does not amplify noise. See #104
+            dxdt_hat[0] = (-3 * x_hat[0] + 4 * x_hat[2] - x_hat[4])/4 # use spaced out stencil to get endpoint formulas
+            dxdt_hat[-1] = (3 * x_hat[-1] - 4 * x_hat[-3] + x_hat[-5])/4          # that do not amplify noise. See #104
         elif order == 4:
             dxdt_hat[2:-2] = (8*(x_hat[3:-1] - x_hat[1:-3]) - x_hat[4:] + x_hat[:-4])/12 # fourth-order center-difference
             dxdt_hat[1] = (x_hat[2] - x_hat[0])/2

--- a/pynumdiff/kalman_smooth/__init__.py
+++ b/pynumdiff/kalman_smooth/__init__.py
@@ -1,5 +1,5 @@
 """This module implements Kalman filters
 """
-from ._kalman_smooth import constant_velocity, constant_acceleration, constant_jerk, known_dynamics
+from ._kalman_smooth import rts_const_deriv, constant_velocity, constant_acceleration, constant_jerk, known_dynamics
 
-__all__ = ['constant_velocity', 'constant_acceleration', 'constant_jerk', 'known_dynamics'] # So these get treated as direct members of the module by sphinx
+__all__ = ['rts_const_deriv', 'constant_velocity', 'constant_acceleration', 'constant_jerk', 'known_dynamics'] # So these get treated as direct members of the module by sphinx

--- a/pynumdiff/kalman_smooth/_kalman_smooth.py
+++ b/pynumdiff/kalman_smooth/_kalman_smooth.py
@@ -81,7 +81,8 @@ def _RTS_smooth(xhat0, P0, y, A, C, Q, R, u=None, B=None):
 # Constant 1st, 2nd, and 3rd derivative #
 #########################################
 def rts_const_deriv(x, dt, order, qr_ratio, forwardbackward):
-    """Perform Rauch-Tung-Striebel smoothing with a constant derivative model.
+    """Perform Rauch-Tung-Striebel smoothing with a constant derivative model. Other constant derivative
+    methods in this module call this function.
 
     :param np.array[float] x: data series to differentiate
     :param float dt: step size

--- a/pynumdiff/optimize/_optimize.py
+++ b/pynumdiff/optimize/_optimize.py
@@ -11,8 +11,8 @@ from ..utils import evaluate
 from ..finite_difference import finite_difference, first_order, second_order, fourth_order
 from ..smooth_finite_difference import mediandiff, meandiff, gaussiandiff, friedrichsdiff, butterdiff, splinediff
 from ..linear_model import spectraldiff, polydiff, savgoldiff, lineardiff
-from ..total_variation_regularization import velocity, acceleration, jerk, iterative_velocity, smooth_acceleration, jerk_sliding
-from ..kalman_smooth import constant_velocity, constant_acceleration, constant_jerk
+from ..total_variation_regularization import tvr, velocity, acceleration, jerk, iterative_velocity, smooth_acceleration, jerk_sliding
+from ..kalman_smooth import rts_const_deriv, constant_velocity, constant_acceleration, constant_jerk
 
 
 # Map from method -> (search_space, bounds_low_hi)
@@ -77,6 +77,9 @@ method_params_and_bounds = {
                            'window_size': [3, 10, 30, 50, 90, 130]},
                           {'gamma': (1e-4, 1e7),
                            'window_size': (3, 1000)}),
+    rts_const_deriv: ({'forwardbackward': [True, False],
+                       'qr_ratio': [-16, -12, -9, -6, -3, 0, 3, 6, 9, 12, 16]},
+                      {'qr_ratio': [1e-20, 1e20]}),
     constant_velocity: ({'forwardbackward': [True, False],
                          'q': [1e-8, 1e-4, 1e-1, 1e1, 1e4, 1e8],
                          'r': [1e-8, 1e-4, 1e-1, 1e1, 1e4, 1e8]},

--- a/pynumdiff/tests/test_diff_methods.py
+++ b/pynumdiff/tests/test_diff_methods.py
@@ -31,8 +31,7 @@ test_funcs_and_derivs = [
 # Call both ways, with kwargs (new) and with params list and optional options dict (legacy), to ensure both work
 diff_methods_and_params = [
     (first_order, {}), (second_order, {}), (fourth_order, {}), # empty dictionary for the case of no parameters
-    (iterated_second_order, {'num_iterations':5}), (iterated_second_order, [5], {'iterate':True}),
-    (iterated_fourth_order, {'num_iterations':10}),
+    (iterated_second_order, {'num_iterations':5}), (iterated_fourth_order, {'num_iterations':10}),
     (lineardiff, {'order':3, 'gamma':5, 'window_size':11, 'solver':'CLARABEL'}), (lineardiff, [3, 5, 11], {'solver':'CLARABEL'}),
     (polydiff, {'poly_order':2, 'window_size':3}), (polydiff, [2, 3]),
     (savgoldiff, {'poly_order':2, 'window_size':5, 'smoothing_win':5}), (savgoldiff, [2, 5, 5]),
@@ -54,7 +53,6 @@ diff_methods_and_params = [
     (smooth_acceleration, {'gamma':2, 'window_size':5}), (smooth_acceleration, [2, 5]),
     (jerk_sliding, {'gamma':1, 'window_size':15}), (jerk_sliding, [1], {'window_size':15})
     ]
-diff_methods_and_params = [(iterated_fourth_order, {'num_iterations':10})]
 
 # All the testing methodology follows the exact same pattern; the only thing that changes is the
 # closeness to the right answer various methods achieve with the given parameterizations. So index a

--- a/pynumdiff/tests/test_diff_methods.py
+++ b/pynumdiff/tests/test_diff_methods.py
@@ -8,7 +8,8 @@ from ..total_variation_regularization import velocity, acceleration, jerk, itera
 from ..kalman_smooth import constant_velocity, constant_acceleration, constant_jerk
 from ..smooth_finite_difference import mediandiff, meandiff, gaussiandiff, friedrichsdiff, butterdiff, splinediff
 # Function alias for testing a case where parameters change the behavior in a big way
-def iterated_first_order(*args, **kwargs): return first_order(*args, **kwargs)
+def iterated_second_order(*args, **kwargs): return second_order(*args, **kwargs)
+def iterated_fourth_order(*args, **kwargs): return fourth_order(*args, **kwargs)
 
 dt = 0.1
 t = np.linspace(0, 3, 31) # sample locations, including the endpoint
@@ -30,7 +31,8 @@ test_funcs_and_derivs = [
 # Call both ways, with kwargs (new) and with params list and optional options dict (legacy), to ensure both work
 diff_methods_and_params = [
     (first_order, {}), (second_order, {}), (fourth_order, {}), # empty dictionary for the case of no parameters
-    (iterated_first_order, {'num_iterations':2}), (iterated_first_order, [2], {'iterate':True}),
+    (iterated_second_order, {'num_iterations':5}), (iterated_second_order, [5], {'iterate':True}),
+    (iterated_fourth_order, {'num_iterations':10}),
     (lineardiff, {'order':3, 'gamma':5, 'window_size':11, 'solver':'CLARABEL'}), (lineardiff, [3, 5, 11], {'solver':'CLARABEL'}),
     (polydiff, {'poly_order':2, 'window_size':3}), (polydiff, [2, 3]),
     (savgoldiff, {'poly_order':2, 'window_size':5, 'smoothing_win':5}), (savgoldiff, [2, 5, 5]),
@@ -52,6 +54,7 @@ diff_methods_and_params = [
     (smooth_acceleration, {'gamma':2, 'window_size':5}), (smooth_acceleration, [2, 5]),
     (jerk_sliding, {'gamma':1, 'window_size':15}), (jerk_sliding, [1], {'window_size':15})
     ]
+diff_methods_and_params = [(iterated_fourth_order, {'num_iterations':10})]
 
 # All the testing methodology follows the exact same pattern; the only thing that changes is the
 # closeness to the right answer various methods achieve with the given parameterizations. So index a
@@ -65,24 +68,30 @@ error_bounds = {
                   [(-25, -25), (1, 0), (0, 0), (1, 1)],
                   [(-25, -25), (2, 2), (0, 0), (2, 2)],
                   [(-25, -25), (3, 3), (0, 0), (3, 3)]],
-    iterated_first_order: [[(-9, -10), (-25, -25), (0, -1), (1, 0)],
-                           [(-9, -10), (-13, -14), (0, -1), (1, 0)],
-                           [(0, 0), (1, 0), (0, 0), (1, 0)],
-                           [(0, 0), (1, 0), (0, 0), (1, 1)],
-                           [(1, 1), (2, 2), (1, 1), (2, 2)],
-                           [(1, 1), (3, 3), (1, 1), (3, 3)]],
     second_order: [[(-25, -25), (-25, -25), (0, 0), (1, 1)],
                    [(-25, -25), (-13, -13), (0, 0), (1, 1)],
                    [(-25, -25), (-13, -13), (0, 0), (1, 1)],
                    [(-25, -25), (0, -1), (0, 0), (1, 1)],
                    [(-25, -25), (1, 1), (0, 0), (1, 1)],
                    [(-25, -25), (3, 3), (0, 0), (3, 3)]],
+    iterated_second_order: [[(-9, -10), (-25, -25), (0, -1), (0, 0)],
+                           [(-9, -10), (-14, -14), (0, -1), (0, 0)],
+                           [(-9, -10), (-13, -14), (0, -1), (0, 0)],
+                           [(0, 0), (1, 0), (0, 0), (1, 0)],
+                           [(1, 1), (2, 2), (1, 1), (2, 2)],
+                           [(1, 1), (3, 3), (1, 1), (3, 3)]],
     fourth_order: [[(-25, -25), (-25, -25), (0, 0), (1, 1)],
                    [(-25, -25), (-13, -13), (0, 0), (1, 1)],
                    [(-25, -25), (-13, -13), (0, 0), (1, 1)],
                    [(-25, -25), (-2, -2), (0, 0), (1, 1)],
                    [(-25, -25), (1, 0), (0, 0), (1, 1)],
                    [(-25, -25), (2, 2), (0, 0), (2, 2)]],
+    iterated_fourth_order: [[(-9, -10), (-25, -25), (0, -1), (0, 0)],
+                            [(-9, -10), (-13, -13), (0, -1), (0, 0)],
+                            [(-1, -1), (0, 0), (-1, -1), (0, 0)],
+                            [(0, -1), (1, 1), (0, 0), (1, 1)],
+                            [(1, 1), (2, 2), (1, 1), (2, 2)],
+                            [(1, 1), (3, 3), (1, 1), (3, 3)]],
     lineardiff: [[(-6, -6), (-5, -6), (0, -1), (0, 0)],
                  [(0, 0), (2, 1), (0, 0), (2, 1)],
                  [(1, 0), (2, 2), (1, 0), (2, 2)],
@@ -144,20 +153,20 @@ error_bounds = {
                  [(1, 0), (2, 2), (1, 0), (2, 2)],
                  [(1, 0), (3, 3), (1, 0), (3, 3)]],
     constant_velocity: [[(-25, -25), (-25, -25), (0, -1), (0, 0)],
-                        [(-6, -6), (-5, -5), (0, -1), (0, 0)],
+                        [(-3, -3), (-2, -2), (0, -1), (0, 0)],
                         [(-1, -2), (0, 0), (0, -1), (0, 0)],
                         [(-1, -1), (1, 0), (0, -1), (1, 0)],
                         [(1, 1), (2, 2), (1, 1), (2, 2)],
                         [(1, 1), (3, 3), (1, 1), (3, 3)]],
     constant_acceleration: [[(-25, -25), (-25, -25), (0, -1), (0, 0)],
-                            [(-5, -6), (-4, -5), (0, -1), (0, 0)],
-                            [(-5, -5), (-4, -4), (0, -1), (0, 0)],
+                            [(-3, -4), (-3, -3), (0, -1), (0, 0)],
+                            [(-3, -3), (-2, -2), (0, -1), (0, 0)],
                             [(-1, -1), (0, 0), (0, -1), (0, 0)],
                             [(1, 1), (2, 2), (1, 1), (2, 2)],
                             [(1, 1), (3, 3), (1, 1), (3, 3)]],
     constant_jerk: [[(-25, -25), (-25, -25), (0, -1), (0, 0)],
-                    [(-5, -5), (-4, -5), (0, -1), (0, 0)],
                     [(-4, -5), (-3, -4), (0, -1), (0, 0)],
+                    [(-3, -4), (-2, -3), (0, -1), (0, 0)],
                     [(-1, -2), (0, 0), (0, -1), (0, 0)],
                     [(1, 0), (2, 1), (1, 0), (2, 1)],
                     [(1, 1), (3, 3), (1, 1), (3, 3)]],

--- a/pynumdiff/tests/test_optimize.py
+++ b/pynumdiff/tests/test_optimize.py
@@ -89,5 +89,5 @@ def test_spectraldiff():
 def test_polydiff():
     params1, val1 = optimize(polydiff, x, dt, search_space={'step_size':1}, dxdt_truth=dxdt_truth, padding='auto')
     params2, val2 = optimize(polydiff, x, dt, search_space={'step_size':1}, tvgamma=tvgamma, dxdt_truth=None, padding='auto')
-    assert (params1['poly_order'], params1['window_size']) == (6, 50)
-    assert (params2['poly_order'], params2['window_size']) == (4, 10)
+    assert (params1['poly_order'], params1['window_size'], params1['kernel']) == (6, 50, 'friedrichs')
+    assert (params2['poly_order'], params2['window_size'], params2['kernel']) == (3, 10, 'gaussian')

--- a/pynumdiff/total_variation_regularization/__init__.py
+++ b/pynumdiff/total_variation_regularization/__init__.py
@@ -2,7 +2,7 @@
 """
 try:
     import cvxpy
-    from ._total_variation_regularization import velocity, acceleration, jerk, jerk_sliding, smooth_acceleration
+    from ._total_variation_regularization import tvr, velocity, acceleration, jerk, jerk_sliding, smooth_acceleration
 except:
     from warnings import warn
     warn("Limited Total Variation Regularization Support Detected! CVXPY is not installed. " +
@@ -12,4 +12,4 @@ except:
 
 from ._total_variation_regularization import iterative_velocity
 
-__all__ = ['velocity', 'acceleration', 'jerk', 'jerk_sliding', 'smooth_acceleration', 'iterative_velocity'] # So these get treated as direct members of the module by sphinx
+__all__ = ['tvr', 'velocity', 'acceleration', 'jerk', 'jerk_sliding', 'smooth_acceleration', 'iterative_velocity'] # So these get treated as direct members of the module by sphinx

--- a/pynumdiff/total_variation_regularization/_total_variation_regularization.py
+++ b/pynumdiff/total_variation_regularization/_total_variation_regularization.py
@@ -56,7 +56,7 @@ def iterative_velocity(x, dt, params=None, options=None, num_iterations=None, ga
 
 def tvr(x, dt, order, gamma, solver=None):
     """Generalized total variation regularized derivatives. Use convex optimization (cvxpy) to solve for a
-    total variation regularized derivative.
+    total variation regularized derivative. Other convex-solver-based method in this module call this function.
 
     :param np.array[float] x: data to differentiate
     :param float dt: step size

--- a/pynumdiff/total_variation_regularization/_total_variation_regularization.py
+++ b/pynumdiff/total_variation_regularization/_total_variation_regularization.py
@@ -54,7 +54,7 @@ def iterative_velocity(x, dt, params=None, options=None, num_iterations=None, ga
     return x_hat, dxdt_hat
 
 
-def _total_variation_regularized_derivative(x, dt, order, gamma, solver=None):
+def tvr(x, dt, order, gamma, solver=None):
     """Generalized total variation regularized derivatives. Use convex optimization (cvxpy) to solve for a
     total variation regularized derivative.
 
@@ -64,7 +64,7 @@ def _total_variation_regularized_derivative(x, dt, order, gamma, solver=None):
     :param float gamma: regularization parameter
     :param str solver: Solver to use. Solver options include: 'MOSEK', 'CVXOPT', 'CLARABEL', 'ECOS'.
                     In testing, 'MOSEK' was the most robust. If not given, fall back to CVXPY's default.
-  
+
     :return: tuple[np.array, np.array] of\n
              - **x_hat** -- estimated (smoothed) x
              - **dxdt_hat** -- estimated derivative of x
@@ -131,7 +131,7 @@ def velocity(x, dt, params=None, options=None, gamma=None, solver=None):
     elif gamma == None:
         raise ValueError("`gamma` must be given.")
 
-    return _total_variation_regularized_derivative(x, dt, 1, gamma, solver=solver)
+    return tvr(x, dt, 1, gamma, solver=solver)
 
 
 def acceleration(x, dt, params=None, options=None, gamma=None, solver=None):
@@ -158,7 +158,7 @@ def acceleration(x, dt, params=None, options=None, gamma=None, solver=None):
     elif gamma == None:
         raise ValueError("`gamma` must be given.")
 
-    return _total_variation_regularized_derivative(x, dt, 2, gamma, solver=solver)
+    return tvr(x, dt, 2, gamma, solver=solver)
 
 
 def jerk(x, dt, params=None, options=None, gamma=None, solver=None):
@@ -185,7 +185,7 @@ def jerk(x, dt, params=None, options=None, gamma=None, solver=None):
     elif gamma == None:
         raise ValueError("`gamma` must be given.")
 
-    return _total_variation_regularized_derivative(x, dt, 3, gamma, solver=solver)
+    return tvr(x, dt, 3, gamma, solver=solver)
 
 
 def smooth_acceleration(x, dt, params=None, options=None, gamma=None, window_size=None, solver=None):
@@ -215,7 +215,7 @@ def smooth_acceleration(x, dt, params=None, options=None, gamma=None, window_siz
     elif gamma == None or window_size == None:
         raise ValueError("`gamma` and `window_size` must be given.")
 
-    _, dxdt_hat = _total_variation_regularized_derivative(x, dt, 2, gamma, solver=solver)
+    _, dxdt_hat = tvr(x, dt, 2, gamma, solver=solver)
 
     kernel = utility.gaussian_kernel(window_size)
     dxdt_hat = utility.convolutional_smoother(dxdt_hat, kernel, 1)
@@ -255,11 +255,11 @@ def jerk_sliding(x, dt, params=None, options=None, gamma=None, solver=None, wind
 
     if len(x) < window_size or window_size < 15:
         warn("len(x) should be > window_size >= 15, calling standard jerk() without sliding")
-        return _total_variation_regularized_derivative(x, dt, 3, gamma, solver=solver)
+        return tvr(x, dt, 3, gamma, solver=solver)
 
     if window_size % 2 == 0:
         window_size += 1 # has to be odd
         warn("Kernel window size should be odd. Added 1 to length.")
     ramp = window_size//5
     kernel = np.hstack((np.arange(1, ramp+1)/ramp, np.ones(window_size - 2*ramp), np.arange(ramp, 0, -1)/ramp))
-    return utility.slide_function(_total_variation_regularized_derivative, x, dt, kernel, 3, gamma, stride=ramp, solver=solver)
+    return utility.slide_function(tvr, x, dt, kernel, 3, gamma, stride=ramp, solver=solver)

--- a/pynumdiff/utils/evaluate.py
+++ b/pynumdiff/utils/evaluate.py
@@ -52,7 +52,7 @@ def plot(x, dt, x_hat, dxdt_hat, x_truth, dxdt_truth, xlim=None, show_error=True
     fig.tight_layout()
 
     if show_error:
-        _, _, rms_dxdt = metrics(x, dt, x_hat, dxdt_hat, x_truth, dxdt_truth)
+        _, _, rms_dxdt = rmse(x, dt, x_hat, dxdt_hat, x_truth, dxdt_truth)
         R_sqr = error_correlation(dxdt_hat, dxdt_truth)
         print('RMS error in velocity: ', rms_dxdt)
         print('Error correlation: ', R_sqr)
@@ -76,8 +76,9 @@ def plot_comparison(dt, dxdt_truth, dxdt_hat1, title1, dxdt_hat2, title2, dxdt_h
     fig.tight_layout()
 
 
-def metrics(x, dt, x_hat, dxdt_hat, x_truth=None, dxdt_truth=None, padding=0):
-    """Evaluate x_hat based on various metrics, depending on whether dxdt_truth and x_truth are known or not.
+def rmse(x, dt, x_hat, dxdt_hat, x_truth=None, dxdt_truth=None, padding=0):
+    """Evaluate x_hat based on RMSE, calculating different ones depending on whether :code:`dxdt_truth`
+    and :code:`x_truth` are known.
 
     :param np.array[float] x: data that was differentiated
     :param float dt: step size


### PR DESCRIPTION
I decided to take on a bit of #138 with a "yes and". The old methods all live where they lived, but I've exposed the common backing methods of TVR, Kalman, and Iterated FD. In the process of the RTS smoothing/Kalman one, I took on #139, because I couldn't help myself.

Of course that then entailed some changes to the tests and to the optimization code. Most profound, I realized Iterated FD has numerical order, but only some are implemented, so the search space of that parameter needs to be categorical. Handling categoricals is a challenge I chose to leave alone last time I worked on the optimizer, but happy to say I've successfully wrestled that bear.