### PR TITLE
Making the house even bigger

### DIFF
--- a/pynumdiff/__init__.py
+++ b/pynumdiff/__init__.py
@@ -7,4 +7,4 @@ from .smooth_finite_difference import meandiff, mediandiff, gaussiandiff, friedr
 from .polynomial_fit import splinediff, polydiff, savgoldiff
 from .total_variation_regularization import tvrdiff, velocity, acceleration, jerk, iterative_velocity, smooth_acceleration, jerk_sliding
 from .kalman_smooth import rtsdiff, constant_velocity, constant_acceleration, constant_jerk, known_dynamics
-from .linear_model import spectraldiff, lineardiff
+from .linear_model import spectraldiff, lineardiff, rbfdiff

--- a/pynumdiff/linear_model/__init__.py
+++ b/pynumdiff/linear_model/__init__.py
@@ -8,8 +8,8 @@ except:
     warn("Limited Linear Model Support Detected! CVXPY is not installed. " +
         "Install CVXPY to use lineardiff derivatives. You can still use other methods.")
 
-from ._linear_model import savgoldiff, polydiff, spectraldiff
+from ._linear_model import savgoldiff, polydiff, spectraldiff, rbfdiff
 
-__all__ = ['lineardiff', 'spectraldiff'] # So these get treated as direct members of the module by sphinx
-# polydiff and savgoldiff are still imported for now for backwards compatibility but are not
-# documented as part of this module, since they've moved
+__all__ = ['lineardiff', 'spectraldiff', 'rbfdiff'] # So these get treated as direct members of the
+# module by sphinx polydiff and savgoldiff are still imported for now for backwards compatibility
+# but are not documented as part of this module, since they've moved

--- a/pynumdiff/linear_model/_linear_model.py
+++ b/pynumdiff/linear_model/_linear_model.py
@@ -231,10 +231,10 @@ def spectraldiff(x, dt, params=None, options=None, high_freq_cutoff=None, even_e
 
 
 def rbfdiff(x, _t, sigma=1, lmbd=0.01):
-    """Find smoothed function and derivative estimates assuming the signal is generated from a Gaussian
-    process, effectively the same assumption the Kalman filter makes. This method works by generating a
-    sparse kernel (naively NxN but truncated to not include tiny values) and solving a linear system
-    using the noisy data as target. It can handle variable step size just as easily as uniform step size.
+    """Find smoothed function and derivative estimates by fitting noisy data against a radial-basis-function-filled
+    kernel (naively NxN but made sparse by truncating tiny values). This function uses a Gaussian kernel, thereby
+    assuming the signal is generated from a Gaussian process, effectively the same assumption the Kalman filter makes.
+    It can handle variable step size just as easily as uniform step size.
 
     :param np.array[float] x: data to differentiate
     :param float or array[float] _t: This function supports variable step size. This parameter is either the constant

--- a/pynumdiff/polynomial_fit/_polynomial_fit.py
+++ b/pynumdiff/polynomial_fit/_polynomial_fit.py
@@ -7,7 +7,7 @@ from pynumdiff.utils import utility
 
 def splinediff(x, _t, params=None, options={}, degree=3, s=None, num_iterations=1):
     """Find smoothed data and derivative estimates by fitting a smoothing spline to the data with
-    scipy.interpolate.UnivariateSpline.
+    scipy.interpolate.UnivariateSpline. Variable step size is supported with equal ease as uniform step size.
 
     :param np.array[float] x: data to differentiate
     :param float or array[float] _t: This function supports variable step size. This parameter is either the constant

--- a/pynumdiff/polynomial_fit/_polynomial_fit.py
+++ b/pynumdiff/polynomial_fit/_polynomial_fit.py
@@ -5,13 +5,13 @@ from warnings import warn
 from pynumdiff.utils import utility
 
 
-def splinediff(x, dt, params=None, options={}, degree=3, s=None, num_iterations=1):
+def splinediff(x, _t, params=None, options={}, degree=3, s=None, num_iterations=1):
     """Find smoothed data and derivative estimates by fitting a smoothing spline to the data with
     scipy.interpolate.UnivariateSpline.
 
     :param np.array[float] x: data to differentiate
-    :param float or array[float] dt: This function supports variable step size. This parameter is either the constant
-        step size if given as a single float, or data locations if given as an array of same length as :code:`x`. 
+    :param float or array[float] _t: This function supports variable step size. This parameter is either the constant
+        step size if given as a single float, or data locations if given as an array of same length as :code:`x`.
     :param list params: (**deprecated**, prefer :code:`degree`, :code:`cutoff_freq`, and :code:`num_iterations`)
     :param dict options: (**deprecated**, prefer :code:`num_iterations`) an empty dictionary or {'iterate': (bool)}
     :param int degree: polynomial degree of the spline. A kth degree spline can be differentiated k times.
@@ -30,11 +30,11 @@ def splinediff(x, dt, params=None, options={}, degree=3, s=None, num_iterations=
         if 'iterate' in options and options['iterate']:
             num_iterations = params[2]
 
-    if isinstance(dt, (np.ndarray, list)): # support variable step size for this function
-        if len(x) != len(dt): raise ValueError("If `dt` is given as array-like, must have same length as `x`.")
-        t = dt
+    if isinstance(_t, (np.ndarray, list)): # support variable step size for this function
+        if len(x) != len(_t): raise ValueError("If `_t` is given as array-like, must have same length as `x`.")
+        t = _t
     else:
-        t = np.arange(len(x))*dt
+        t = np.arange(len(x))*_t
 
     x_hat = x
     for _ in range(num_iterations):


### PR DESCRIPTION
Added a fun but mildly redundant method inspired by KernelDiff, authored by @Jacob-Stevens-Haas in the derivative package. My version is based on sparse matrices for $O(N \sigma)$ efficiency.

I haven't bothered to add usage examples to the Jupyter notebooks, though I have added docstrings, so it'll end up on readthedocs.