### PR TITLE
handling array-like inputs

### DIFF
--- a/pynumdiff/basis_fit/_basis_fit.py
+++ b/pynumdiff/basis_fit/_basis_fit.py
@@ -38,9 +38,9 @@ def spectraldiff(x, dt, params=None, options=None, high_freq_cutoff=None, even_e
     # make derivative go to zero at ends (optional)
     if pad_to_zero_dxdt:
         padding = 100
-        pre = x[0]*np.ones(padding) # extend the edges
-        post = x[-1]*np.ones(padding)
-        x = np.hstack((pre, x, post))
+        pre = getattr(x, 'values', x)[0]*np.ones(padding) # getattr to use .values if x is a pandas Series
+        post = getattr(x, 'values', x)[-1]*np.ones(padding)
+        x = np.hstack((pre, x, post)) # extend the edges
         kernel = utility.mean_kernel(padding//2)
         x_hat = utility.convolutional_smoother(x, kernel) # smooth the edges in
         x_hat[padding:-padding] = x[padding:-padding] # replace middle with original signal

--- a/pynumdiff/finite_difference/_finite_difference.py
+++ b/pynumdiff/finite_difference/_finite_difference.py
@@ -17,7 +17,7 @@ def finitediff(x, dt, num_iterations, order):
     if num_iterations < 1: raise ValueError("num_iterations must be >0")
     if order not in [1, 2, 4]: raise ValueError("order must be 1, 2, or 4")
 
-    x_hat = x # preserve a reference to x, because if iterating we need it to find the final constant of integration
+    x_hat = np.asarray(x) # allows for array-like. Preserve reference to x, for finding the final constant of integration
     dxdt_hat = np.zeros(x.shape) # preallocate reusable memory
 
     # For all but the last iteration, do the differentate->integrate smoothing loop, being careful with endpoints


### PR DESCRIPTION
fixing little indexing bugs that kept finitediff and spectraldiff from working with pandas Series input, which are array-like enough that we'd like to seamlessly handle

Addresses #156