### PR TITLE
Deploy workflow + Coveralls

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,18 @@
+on:
+  release:
+    types: [created]
+jobs:
+  deploy-to-pypi:
+    runs-on: ubuntu-latest
+    env:
+      TWINE_USERNAME: __token__
+      TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.x'
+    - run: |
+        pip install build wheel twine
+        python -m build
+        twine upload dist/*

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
 
 jobs:
-  Linux:
+  run-tests:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -13,8 +13,10 @@ jobs:
         with:
           python-version: '3.x'
 
-      - name: tests
+      - name: tests and coverage
         run: |
-          pip install -e .[advanced,dev]
-          pytest pynumdiff
-
+          pip install -e .[advanced,dev] coveralls
+          coverage run --source=pynumdiff -m pytest -s
+          coveralls
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}


### PR DESCRIPTION
Addressing #147. Added coveralls to the tests workflow and added the ability to deploy to pypi with another workflow. All that's missing are secrets.